### PR TITLE
Update installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,12 @@ Using the third major function `fancy_plotting`, the final model then undergoes 
 et al. 2019) for data handling, and `MuMIn` (Bartoń 2024) for calculation of AICc scores. For generation of plots visualizing regression, effect size, and estimates, the script further leverages `tidyverse` and color palettes included in the `colorspace` (Zeileis et al. 2020) and `viridis` (Garnier et al. 2024) R packages.
 
 # How to install
-You have two options to install `LazyModeler`. You can either install through GitHub using the `devtools` library.
+You have two options to install `LazyModeler`. You can either install through GitHub using the `remotes` package.
 ``` r
-library("devtools")
-install_github("LMKoesters/LazyModeler")
+remotes::install_github("LMKoesters/LazyModeler")
 ```
 
-For the second option, you need to download the tarball from GitHub and then install using `install.packages`.
+Alternatively, you need to download the tarball from GitHub and then install using `install.packages`.
 ``` r
 install.packages("PATH_TO_TARBALL/LazyModeler-v.0.2.0.tar.gz", repos = NULL, type="source")
 ```


### PR DESCRIPTION
Related to openjournals/joss-reviews#8127

This PR provides more standard installation instructions:

1. it is a package, not a library - the latter is where packages are installed,
2. use the *remotes* package directly to install, *devtools* just re-exports `remotes::install_github()` and loads a lot of stuff a user doesn't need just to use your package
3. to that same end, don't load and attach *remotes*, just load it by calling `remotes::install_github()` instead of calling `library()` then `install_github()`.